### PR TITLE
Make destroy work. Plus, add Proxy to allow "computed" stack plans

### DIFF
--- a/src/base-component.js
+++ b/src/base-component.js
@@ -3,6 +3,7 @@ const path = require("path");
 class BaseComponent {
   constructor(name) {
     this.name = name;
+    this.output = wrap({});
   }
 
   configure(input) {
@@ -19,6 +20,18 @@ class BaseComponent {
     this.baseDir = baseDir;
     this.workingDir = path.join(baseDir, this.name);
   }
+
+  setOutput(output) {
+    this.output = wrap(output);
+  }
 }
+
+const wrap = obj => {
+  return new Proxy(obj, {
+    get(target, propKey) {
+      return target[propKey] || { value: "<computed>" };
+    }
+  });
+};
 
 module.exports = BaseComponent;

--- a/src/internals/terraform.js
+++ b/src/internals/terraform.js
@@ -84,7 +84,7 @@ class Terraform {
     eventbus.emit("component:output:start", this.component);
     await this._exec("output -json").then(
       output => {
-        this.component.output = JSON.parse(output);
+        this.component.setOutput(JSON.parse(output));
         eventbus.emit(`component:output:success`, this.component);
       },
       code => {


### PR DESCRIPTION
This allows the following:

- Stack destroy
- Plan the entire stack from scratch by injecting a `<computed>` output value
- Destroy the stack without having to provide inputs from dependencies, by injecting `<computed>`

The injecting is done via a proxy class. It's a pretty simple approach, but it works at least in the complex example. Would probably fail for complex hcl types (lists / map).